### PR TITLE
fix docker-compose node_module caching

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     command: yarn run dev --host 0.0.0.0 --port 8000
     volumes:
       - .:/app
+      - /app/node_modules
 
   nginx:
     extends:


### PR DESCRIPTION
Previously node_modules were being generated in the image
and then the local directory was mounted over top. This resulted
in the local node_modules being used instead of those in the docker
image. Now we specify another override so that the container uses
the node_modules generated in the image.