### PR TITLE
Add NPM settings for datadog agent

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -28,6 +28,7 @@ services:
       - DD_LOGS_ENABLED=true
       - DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true
       - DD_PROCESS_AGENT_ENABLED=true
+      - DD_SYSTEM_PROBE_ENABLED=true
     build:
       context: ./docker/datadog
       dockerfile: ./Dockerfile
@@ -36,3 +37,12 @@ services:
       - /proc/:/host/proc/:ro
       - /sys/fs/cgroup:/host/sys/fs/cgroup:ro
       - /etc/passwd:/etc/passwd:ro
+      - /sys/kernel/debug:/sys/kernel/debug
+    cap_add:
+      - IPC_LOCK
+      - NET_ADMIN
+      - SYS_ADMIN
+      - SYS_PTRACE
+      - SYS_RESOURCE
+    security_opt:
+      - apparmor:unconfined


### PR DESCRIPTION
As per: https://docs.datadoghq.com/network_monitoring/performance/setup/?tab=docker

Probably isn't super useful as per the above page:

> Given this tool’s focus and strength is in analyzing traffic between network endpoints and mapping network dependencies, it is recommended to install it on a meaningful subset of your infrastructure and a minimum of 2 hosts to maximize value.

and we only have 1 host but :man_shrugging:  