### PR TITLE
Revert "Add NPM settings for datadog agent"

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -28,7 +28,6 @@ services:
       - DD_LOGS_ENABLED=true
       - DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true
       - DD_PROCESS_AGENT_ENABLED=true
-      - DD_SYSTEM_PROBE_ENABLED=true
     build:
       context: ./docker/datadog
       dockerfile: ./Dockerfile
@@ -37,12 +36,3 @@ services:
       - /proc/:/host/proc/:ro
       - /sys/fs/cgroup:/host/sys/fs/cgroup:ro
       - /etc/passwd:/etc/passwd:ro
-      - /sys/kernel/debug:/sys/kernel/debug
-    cap_add:
-      - IPC_LOCK
-      - NET_ADMIN
-      - SYS_ADMIN
-      - SYS_PTRACE
-      - SYS_RESOURCE
-    security_opt:
-      - apparmor:unconfined


### PR DESCRIPTION
Reverts crossroadsinajax/website#35 as we're seeing a steady rise in CPU for the Datadog agent again