### PR TITLE
correct docker-compose file versions

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '2.4'
 
 services:
   app:

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '2.4'
 
 # Override the default docker-compose.yml with dev settings
 services:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '2.4'
 
 services:
   app:

--- a/prod.yml
+++ b/prod.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '2.4'
 
 # GIT_TAG must be defined in .env
 

--- a/staging.yml
+++ b/staging.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '2.4'
 
 # Unfortunately we can't extend prod.yml as the volumes
 # will be combined rather than overridden.


### PR DESCRIPTION
https://docs.docker.com/compose/compose-file/compose-versioning/

`extends` was removed in version 3.0 we should probably upgrade:

  - https://docs.docker.com/compose/extends/#extending-services