### PR TITLE
Add Django caching

### DIFF
--- a/crossroads/settings/base.py
+++ b/crossroads/settings/base.py
@@ -107,6 +107,12 @@ DATABASES = {
     }
 }
 
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+    }
+}
+
 AUTH_USER_MODEL = "church.User"
 
 # https://docs.djangoproject.com/en/3.0/ref/settings/#auth-password-validators


### PR DESCRIPTION
Seems like one of the biggest perf issues is when group sends are done which requires synchronous access to the database for session in the chat.

https://app.datadoghq.com/apm/traces?end=1615741749228&paused=false&query=env%3Aprod%20%40duration%3A%3E%3D170ms&spanID=4910598466579008056&start=1615739949228&storage=hot&streamTraces=true&trace=AQAAAXgxsRNYsedRwwAAAABBWGd4c2VJNUFBQnY4X3NtcHlVTm9GQmo&traceID=7156448459400454532

https://app.datadoghq.com/profiling/8c48b3bd-a7ae-4a99-980e-e8bfdf7fb369?agg_m=%40prof_core_cpu_cores&agg_q=service&agg_t=sum&end=1615741835171&event=AQAAAXgxnA2wTRLldwAAAABBWGd4bk14cEFBQUd1V3hZWWlKMHhBQUE&paused=false&start=1615738235171


