### PR TITLE
Handle null bulletins

### DIFF
--- a/web/components/Bulletin.tsx
+++ b/web/components/Bulletin.tsx
@@ -91,6 +91,9 @@ export const Bulletin: React.FC<{
     return <div></div>
   }
 
+  // Bulletins can be null.
+  if (!("value" in bulletin)) return <div></div>
+
   var bulletinSection: BulletinSectionProp
   try {
     let bulletinItems: BulletinItemProp[] = []


### PR DESCRIPTION
This case was handled by the error handling but created some noise since
null bulletins are permitted in the data model.

Fixes #203 