### PR TITLE
Prune docker before deploying

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,6 +28,7 @@ jobs:
           eval $(ssh-agent)
           ssh-add "$HOME/.ssh/docker"
           echo "crossroadsajax.church $SSH_KNOWN_HOST" >> ~/.ssh/known_hosts
+          ssh kyle@crossroadsajax.church "docker system prune"
           docker --host "ssh://kyle@crossroadsajax.church" \
             stack deploy --compose-file <(docker-compose \
             -f prod.yml config) --with-registry-auth prod
@@ -59,6 +60,7 @@ jobs:
           eval $(ssh-agent)
           ssh-add "$HOME/.ssh/docker"
           echo "crossroadsajax.church $SSH_KNOWN_HOST" >> ~/.ssh/known_hosts
+          ssh kyle@crossroadsajax.church "docker system prune"
           docker --host "ssh://kyle@crossroadsajax.church" \
             stack deploy --compose-file <(docker-compose \
             -f staging.yml config) --with-registry-auth staging


### PR DESCRIPTION
There isn't much disk free on cia-1 and old images need to be cleaned up
every few deploys which is annoying to have to keep doing manually.


Resolves #205 