### PR TITLE
Replace hypercorn with uvicorn

### DIFF
--- a/prod.yml
+++ b/prod.yml
@@ -15,7 +15,7 @@ services:
     command: >
       sh -c "python manage.py migrate &&
              python manage.py loaddata groups &&
-             ddtrace-run hypercorn --websocket-ping-interval=1 --worker-class=uvloop --workers=1 --bind=0.0.0.0:8000 crossroads.asgi:application"
+             ddtrace-run uvicorn --host=0.0.0.0 --port=8000 --loop=uvloop --ws=websockets crossroads.asgi:application"
     secrets:
       - django_secret
       - postmark_api_key

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ click==7.1.2
 constantly==15.1.0
 cryptography==3.4.6
 daphne==3.0.1
-ddtrace==0.50.0
+ddtrace==0.50.2
 distlib==0.3.1
 Django==3.1.12
 django-extensions==2.2.9
@@ -35,12 +35,7 @@ graphene==2.1.8
 graphene-django==2.13.0
 graphql-core==2.3.2
 graphql-relay==2.0.1
-h11==0.12.0
-h2==4.0.0
-hpack==4.0.0
 html5lib==1.1
-Hypercorn==0.11.2
-hyperframe==6.0.1
 hyperlink==21.0.0
 idna==2.10
 incremental==21.3.0
@@ -81,13 +76,13 @@ typed-ast==1.4.3
 typing-extensions==3.10.0.0
 Unidecode==1.2.0
 urllib3==1.26.5
+uvicorn[standard]==0.14.0
 uvloop==0.15.2
 virtualenv==20.4.3
 wagtail==2.12.5
 wagtailmedia==0.5.0
 webencodings==0.5.1
 Willow==1.4
-wsproto==1.0.0
 xlrd==2.0.1
 XlsxWriter==1.3.7
 xlwt==1.3.0


### PR DESCRIPTION
Hypercorn seems to have some odd memory leak with websockets where they
leak memory which also results in increasing CPU usage until the app
crashes. Hopefully uvicorn does not have the same issue...