### PR TITLE
Add tracing to nginx

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -30,6 +30,7 @@ services:
       dockerfile: ./docker/web/Dockerfile
 
   nginx:
+    platform: linux/amd64
     restart: always
 
   datadog:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,8 @@ services:
     restart: always
     ports:
       - 8000:80
+    environment:
+      - DD_ENV=dev
 
   datadog:
     extends:

--- a/docker/nginx_dev/Dockerfile
+++ b/docker/nginx_dev/Dockerfile
@@ -1,4 +1,22 @@
-FROM nginx:1.17.3-alpine
+FROM nginx:1.17.3
+
+RUN apt-get update && apt-get install -y wget tar
 
 RUN rm /etc/nginx/conf.d/default.conf
-COPY nginx.conf /etc/nginx/conf.d
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY dd-config.json /etc/nginx/dd-config.json
+
+
+# Install nginx-opentracing
+RUN get_latest_release() { \
+  wget -qO- "https://api.github.com/repos/$1/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'; \
+  } && \
+  NGINX_VERSION=`nginx -v 2>&1 > /dev/null | sed -E "s/^.*nginx\/(.*)/\\1/"`&& \
+  OPENTRACING_NGINX_VERSION="$(get_latest_release opentracing-contrib/nginx-opentracing)" && \
+  DD_OPENTRACING_CPP_VERSION="$(get_latest_release DataDog/dd-opentracing-cpp)" && \
+  \
+  wget https://github.com/opentracing-contrib/nginx-opentracing/releases/download/${OPENTRACING_NGINX_VERSION}/linux-amd64-nginx-${NGINX_VERSION}-ot16-ngx_http_module.so.tgz && \
+  NGINX_MODULES=$(nginx -V 2>&1 | grep "configure arguments" | sed -n 's/.*--modules-path=\([^ ]*\).*/\1/p') && \
+  tar zxvf linux-amd64-nginx-${NGINX_VERSION}-ot16-ngx_http_module.so.tgz -C "${NGINX_MODULES}" && \
+  # Install Datadog module
+  wget -O - https://github.com/DataDog/dd-opentracing-cpp/releases/download/${DD_OPENTRACING_CPP_VERSION}/linux-amd64-libdd_opentracing_plugin.so.gz | gunzip -c > /usr/local/lib/libdd_opentracing_plugin.so

--- a/docker/nginx_dev/dd-config.json
+++ b/docker/nginx_dev/dd-config.json
@@ -1,0 +1,6 @@
+{
+  "service": "nginx",
+  "operation_name_override": "nginx.handle",
+  "agent_host": "datadog",
+  "agent_port": 8126
+}

--- a/docker/nginx_dev/nginx.conf
+++ b/docker/nginx_dev/nginx.conf
@@ -1,38 +1,58 @@
-upstream django {
-  server app:8000;
-}
+env DD_ENV;
+load_module modules/ngx_http_opentracing_module.so;
 
-upstream webpack {
-  server web:8000;
-}
+events {}
 
-server {
-  listen 80;
-  absolute_redirect off;
+http {
+  opentracing_load_tracer /usr/local/lib/libdd_opentracing_plugin.so /etc/nginx/dd-config.json;
+  opentracing on;
+  opentracing_tag http_user_agent $http_user_agent;
+  opentracing_trace_locations off;
+  opentracing_operation_name "$request_method $uri";
+  log_format with_trace_id '$remote_addr - $http_x_forwarded_user [$time_local] "$request" '
+     '$status $body_bytes_sent "$http_referer" '
+     '"$http_user_agent" "$http_x_forwarded_for" '
+     '"$opentracing_context_x_datadog_trace_id" "$opentracing_context_x_datadog_parent_id"';
+  access_log /var/log/nginx/access.log with_trace_id;
 
-  location ~ ^/(gql|static|admin|django-admin|ws)/ {
-    proxy_pass http://django;
-
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade";
-
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header Host $host;
-    proxy_redirect off;
+  upstream django {
+    server app:8000;
   }
 
-  location / {
-    proxy_pass http://webpack;
+  upstream webpack {
+    server web:8000;
+  }
 
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade";
+  server {
+    listen 80;
+    absolute_redirect off;
 
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header Host $host;
-    proxy_redirect off;
+    location ~ ^/(gql|static|admin|django-admin|ws)/ {
+      opentracing_propagate_context;
+      proxy_pass http://django;
+
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $host;
+      proxy_redirect off;
+    }
+
+    location / {
+      opentracing_propagate_context;
+      proxy_pass http://webpack;
+
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $host;
+      proxy_redirect off;
+    }
   }
 }

--- a/docker/nginx_prod/Dockerfile
+++ b/docker/nginx_prod/Dockerfile
@@ -1,4 +1,21 @@
-FROM nginx:1.17.3-alpine
+FROM nginx:1.17.3
+
+RUN apt-get update && \
+  apt-get install -y wget tar
 
 RUN rm /etc/nginx/conf.d/default.conf
 COPY nginx.conf /etc/nginx/conf.d
+
+# Install nginx-opentracing
+RUN get_latest_release() { \
+  wget -qO- "https://api.github.com/repos/$1/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'; \
+  } && \
+  NGINX_VERSION=`nginx -v 2>&1 > /dev/null | sed -E "s/^.*nginx\/(.*)/\\1/"`&& \
+  OPENTRACING_NGINX_VERSION="$(get_latest_release opentracing-contrib/nginx-opentracing)" && \
+  DD_OPENTRACING_CPP_VERSION="$(get_latest_release DataDog/dd-opentracing-cpp)" && \
+  \
+  wget https://github.com/opentracing-contrib/nginx-opentracing/releases/download/${OPENTRACING_NGINX_VERSION}/linux-amd64-nginx-${NGINX_VERSION}-ot16-ngx_http_module.so.tgz && \
+  NGINX_MODULES=$(nginx -V 2>&1 | grep "configure arguments" | sed -n 's/.*--modules-path=\([^ ]*\).*/\1/p') && \
+  tar zxvf linux-amd64-nginx-${NGINX_VERSION}-ot16-ngx_http_module.so.tgz -C "${NGINX_MODULES}" && \
+  # Install Datadog module
+  wget -O - https://github.com/DataDog/dd-opentracing-cpp/releases/download/${DD_OPENTRACING_CPP_VERSION}/linux-amd64-libdd_opentracing_plugin.so.gz | gunzip -c > /usr/local/lib/libdd_opentracing_plugin.so

--- a/docker/nginx_prod/dd-config.json
+++ b/docker/nginx_prod/dd-config.json
@@ -1,0 +1,6 @@
+{
+  "service": "nginx",
+  "operation_name_override": "nginx.handle",
+  "agent_host": "datadog",
+  "agent_port": 8126
+}

--- a/docker/nginx_prod/nginx.conf
+++ b/docker/nginx_prod/nginx.conf
@@ -1,28 +1,47 @@
-upstream crossroads {
-  server app:8000;
-}
+env DD_ENV;
+load_module modules/ngx_http_opentracing_module.so;
 
-server {
-  listen 80;
+events {}
 
-  location /static {
-    alias /static;
+http {
+  opentracing_load_tracer /usr/local/lib/libdd_opentracing_plugin.so /etc/nginx/dd-config.json;
+  opentracing on;
+  opentracing_tag http_user_agent $http_user_agent;
+  opentracing_trace_locations off;
+  opentracing_operation_name "$request_method $uri";
+  log_format with_trace_id '$remote_addr - $http_x_forwarded_user [$time_local] "$request" '
+     '$status $body_bytes_sent "$http_referer" '
+     '"$http_user_agent" "$http_x_forwarded_for" '
+     '"$opentracing_context_x_datadog_trace_id" "$opentracing_context_x_datadog_parent_id"';
+  access_log /var/log/nginx/access.log with_trace_id;
+
+  upstream crossroads {
+    server app:8000;
   }
 
-  location ~ ^/(apple-touch-icon|browserconfig|favicon|mstile)(.*)\.(png|xml|ico)$ {
-    root /static/;
-  }
+  server {
+    listen 80;
 
-  location / {
-    proxy_pass http://crossroads;
+    location /static {
+      alias /static;
+    }
 
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection "upgrade";
+    location ~ ^/(apple-touch-icon|browserconfig|favicon|mstile)(.*)\.(png|xml|ico)$ {
+      root /static/;
+    }
 
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header Host $host;
-    proxy_redirect off;
+    location / {
+      opentracing_propagate_context;
+      proxy_pass http://crossroads;
+
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $host;
+      proxy_redirect off;
+    }
   }
 }

--- a/prod.yml
+++ b/prod.yml
@@ -62,6 +62,8 @@ services:
       - 8000:80
     volumes:
       - staticfiles:/static
+    environment:
+      - DD_ENV=prod
 
   datadog:
     extends:


### PR DESCRIPTION
This was done using: https://docs.datadoghq.com/tracing/setup_overview/proxy_setup/?tab=nginx

and realizing that a platform has to be specified for the docker
container as the instructions use amd64 binaries.

Resolves: https://github.com/crossroadsinajax/website/issues/222