### PR TITLE
Fix bulletin

### DIFF
--- a/crossroads/settings/base.py
+++ b/crossroads/settings/base.py
@@ -176,6 +176,7 @@ USE_TZ = True
 
 SESSION_COOKIE_AGE = 2 * 365 * 24 * 60 * 60
 
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.0/howto/static-files/


### PR DESCRIPTION
Bulletin items broke as wagtail introduced a change somewhere in
versions 2.12-2.16 to the schema of the raw data of StructBlock items.
The data used to be of the shape:

```
{'title': "Men's Group", 'date': '2021-06-14', 'contact_name': 'Ralph Vanderwel', 'contact_email': 'rnvanderwel@gmail.com', 'contact_phone': '', 'body': '<p>The men at Crossroads will be meeting online every second Monday at 7:30 pm. Feel free to join! Contact Ralph Vanderwel at <a href="mailto:rnvanderwel@gmail.com">rnvanderwel@gmail.com</a> for Zoom online link details.</p>'}
```

and now looks like:

```
{'type': 'item', 'value': {'title': "Men's Group", 'date': '2021-06-14', 'contact_name': 'Ralph Vanderwel', 'contact_email': 'rnvanderwel@gmail.com', 'contact_phone': '', 'body': '<p data-block-key="k78xv">The men at Crossroads will be meeting online every second Monday at 7:30 pm. Feel free to join! Contact Ralph Vanderwel at <a href="mailto:rnvanderwel@gmail.com">rnvanderwel@gmail.com</a> for Zoom online link details.</p>'}, 'id': 'f0cdafac-1c6e-4f17-9cb3-8888261c9f38'}
```

(The actual data is now nested within a `"value"` dictionary.)

The annoying part is that old items will be changed when the item is
saved so we have to handle both data schemas.

Fix #269