### PR TITLE
Add telemetry for email sending

### DIFF
--- a/church/admin.py
+++ b/church/admin.py
@@ -1,9 +1,14 @@
+import logging
+
+from ddtrace import tracer
 from django.contrib import admin, messages
 from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
 from django.contrib.auth.forms import UserCreationForm
 
 from . import email
 from .models import User
+
+log = logging.getLogger(__name__)
 
 
 def daily_reading_email(modeladmin, request, queryset):
@@ -25,12 +30,14 @@ def bulletin_email(modeladmin, request, queryset):
 
 
 def service_email(modeladmin, request, queryset):
-    try:
-        email.send_service(queryset)
-    except Exception as e:
-        messages.error(request, f"Error: {e}")
-    else:
-        messages.success(request, f"{len(queryset)} email(s) sent successfully!")
+    with tracer.trace("email"):
+        try:
+            email.send_service(queryset)
+        except Exception as e:
+            log.exception("error sending service email")
+            messages.error(request, f"Error: {e}")
+        else:
+            messages.success(request, f"{len(queryset)} email(s) sent successfully!")
 
 
 class UserCreateForm(UserCreationForm):


### PR DESCRIPTION
The emails failed to send with an unhelpful error message. Add some
telemetry to make debugging the email sending easier.